### PR TITLE
Updated bootstrap version from 3.1.0 to 3.1.1 for bower

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -7,7 +7,7 @@
   ],
   "dependencies": {
     "wysihtml5": "~0.3.0",
-    "bootstrap": "~3.1.0",
+    "bootstrap": "~3.1.1",
     "handlebars": "~1.3.0",
     "jquery": ">=1.9.0 <2.1.0"
   },


### PR DESCRIPTION
Fix for https://github.com/Waxolunist/bootstrap3-wysihtml5-bower/issues/64
